### PR TITLE
Improve cross-platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+jpm_tree


### PR DESCRIPTION
There is an open PR from January (#18) that aims to add macOS/iOS support.

While I appreciate I'm biased, I'd suggest this PR be merged instead. I've added support for Apple platforms, Windows and BSD. I've does this using the `JANET_` defines that are defined in `janet.h` rather than relying on constants in the compiler.